### PR TITLE
manifest: use http://purl.org/dc/terms/ for dcterms

### DIFF
--- a/manifest.ttl
+++ b/manifest.ttl
@@ -1,5 +1,5 @@
 @prefix test: <http://www.w3.org/2006/03/test-description#> .
-@prefix dcterms: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix rdb2rdftest: <http://purl.org/NET/rdb2rdf-test#> .
 @base <http://www.w3.org/2001/sw/rdb2rdf/test-cases/> .
 


### PR DESCRIPTION
http://purl.org/dc/elements/1.1/ is still supported, but is considered legacy.

See https://github.com/kg-construct/r2rml-implementation-report/pull/18