### PR TITLE
Added PAD_CHAR_TO_FULL_LENGTH to MySQL startup

### DIFF
--- a/databases/docker-compose-mysql.yml
+++ b/databases/docker-compose-mysql.yml
@@ -11,4 +11,4 @@ services:
       MYSQL_DATABASE: r2rml
     ports:
       - "3306:3306"
-    command: --sql_mode="ANSI_QUOTES"
+    command: --sql_mode="ANSI_QUOTES,PAD_CHAR_TO_FULL_LENGTH"


### PR DESCRIPTION
PAD_CHAR_TO_FULL_LENGTH is needed to ensure that CHAR(n) behaves like
ANSI CHAR(n), otherwise R2RMLTC0018a fails. The MySQL community has
decided that padding isn't sufficiently useful "in the wild" and has
deprecated this mode. It will soon be removed from MySQL.

See https://github.com/kg-construct/r2rml-test-cases-support/issues/10