### PR TITLE
Added note about MySQL timezones to the README (fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ engine_command: java -jar morph-rdb.jar -p properties.properties # command to ru
 7. Upload or update the obtained results the access point you have provided in the configuration step.
 8. For each new version of your engine, repeat the process from step 4 to 7.
 
+### Notes
+The MySQL Docker container stores timestamps as UTC. Values that are retrieved from the database may therefore not correspond with the time zone of the host. If you notice that a test fails because the times are off, try appending `?useLegacyDatetimeCode=false&serverTimezone=XXX`, where `XXX` corresponds with your [IANA Time Zone Database](https://www.iana.org/time-zones) entry (e.g., `Europe/Brussels`), to the JDBC connection URL.
+
 
 Overview of the testing steps:
 ![Testing setp](misc/test.png?raw=true "Testing setp")

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ engine_command: java -jar morph-rdb.jar -p properties.properties # command to ru
 7. Upload or update the obtained results the access point you have provided in the configuration step.
 8. For each new version of your engine, repeat the process from step 4 to 7.
 
-### Notes
-The MySQL Docker container stores timestamps as UTC. Values that are retrieved from the database may therefore not correspond with the time zone of the host. If you notice that a test fails because the times are off, try appending `?useLegacyDatetimeCode=false&serverTimezone=XXX`, where `XXX` corresponds with your [IANA Time Zone Database](https://www.iana.org/time-zones) entry (e.g., `Europe/Brussels`), to the JDBC connection URL.
-
 
 Overview of the testing steps:
 ![Testing setp](misc/test.png?raw=true "Testing setp")
 
+
+### Notes
+The MySQL Docker container stores timestamps as UTC. Values that are retrieved from the database may therefore not correspond with the time zone of the host. If you notice that a test fails because the times are off, try appending `?useLegacyDatetimeCode=false&serverTimezone=XXX`, where `XXX` corresponds with your [IANA Time Zone Database](https://www.iana.org/time-zones) entry (e.g., `Europe/Brussels`), to the JDBC connection URL.

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Overview of the testing steps:
 
 
 ### Notes
-The MySQL Docker container stores timestamps as UTC. Values that are retrieved from the database may therefore not correspond with the time zone of the host. If you notice that a test fails because the times are off, try appending `?useLegacyDatetimeCode=false&serverTimezone=XXX`, where `XXX` corresponds with your [IANA Time Zone Database](https://www.iana.org/time-zones) entry (e.g., `Europe/Brussels`), to the JDBC connection URL.
+- The MySQL Docker container stores timestamps as UTC. Values that are retrieved from the database may therefore not correspond with the time zone of the host. If you notice that a test fails because the times are off, try appending `?useLegacyDatetimeCode=false&serverTimezone=XXX`, where `XXX` corresponds with your [IANA Time Zone Database](https://www.iana.org/time-zones) entry (e.g., `Europe/Brussels`), to the JDBC connection URL.

--- a/databases/docker-compose-mysql.yml
+++ b/databases/docker-compose-mysql.yml
@@ -11,4 +11,4 @@ services:
       MYSQL_DATABASE: r2rml
     ports:
       - "3306:3306"
-    command: --sql_mode="ANSI_QUOTES"
+    command: --sql_mode="ANSI_QUOTES,PAD_CHAR_TO_FULL_LENGTH"


### PR DESCRIPTION
Instructions to ensure that test doesn't fail when the host's time zone is different from the docker container's time zone.