### PR TITLE
Change order of table drops for running tests sequentially with a MySQL source

### DIFF
--- a/databases/d009.sql
+++ b/databases/d009.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS "Sport" cascade;
 DROP TABLE IF EXISTS "Student" cascade;
+DROP TABLE IF EXISTS "Sport" cascade;
 CREATE TABLE "Sport" ("ID" integer,"Name" varchar (50),PRIMARY KEY ("ID"));
 CREATE TABLE "Student" ("ID" integer,"Name" varchar(50),"Sport" integer,PRIMARY KEY ("ID"), FOREIGN KEY("Sport") REFERENCES "Sport"("ID"));
 INSERT INTO "Sport" ("ID", "Name") VALUES (100,'Tennis');


### PR DESCRIPTION
While implementing these test cases for [RMLMapper](https://github.com/RMLio/rmlmapper-java) some tests cases crashed with exception for D009. After investigation, it was determined that this was caused by the SQL script failing to instantiate D009 which drops a table that is used for a foreign key reference before dropping the referencing table:

```sql
-- original script
DROP TABLE IF EXISTS "Student" cascade;
DROP TABLE IF EXISTS "Sport" cascade;
CREATE TABLE "Sport" ("ID" integer,"Name" varchar (50),PRIMARY KEY ("ID"));
CREATE TABLE "Student" ("ID" integer,"Name" varchar(50),"Sport" integer,PRIMARY KEY ("ID"), FOREIGN KEY("Sport") REFERENCES "Sport"("ID"));
...
```

Some database systems can handle this order (our PostgreSQL tests ran fine), but to avoid any conflicts, I propose to change the order of dropping tables such that the referencing table is dropped first:

```sql
-- adaptation
DROP TABLE IF EXISTS "Student" cascade;
DROP TABLE IF EXISTS "Sport" cascade;
...
```
