### PR TITLE
Fix inconsistent pairings of mapping files and expected output: 0005b, 0012a, 0012e

### DIFF
--- a/R2RMLTC0005b/r2rmlb.ttl
+++ b/R2RMLTC0005b/r2rmlb.ttl
@@ -9,7 +9,7 @@
     
     rr:logicalTable [ rr:tableName "\"IOUs\"" ];
 
-    rr:subjectMap [ rr:template "{\"fname\"}_{\"lname\"}";
+    rr:subjectMap [ rr:template "{\"fname\"}{\"lname\"}";
                     rr:class <IOUs>;
                     rr:termType rr:BlankNode; ];
 

--- a/R2RMLTC0012a/r2rmla.ttl
+++ b/R2RMLTC0012a/r2rmla.ttl
@@ -9,7 +9,7 @@
 
 	rr:logicalTable [ rr:tableName  "\"IOUs\"" ];
 	
-    rr:subjectMap [ rr:template "{\"fname\"}_{\"lname\"}_{\"amount\"}"; rr:termType rr:BlankNode; ];
+    rr:subjectMap [ rr:template "{\"fname\"}{\"lname\"}{\"amount\"}"; rr:termType rr:BlankNode; ];
 	
     rr:predicateObjectMap
     [ 

--- a/R2RMLTC0012e/r2rmle.ttl
+++ b/R2RMLTC0012e/r2rmle.ttl
@@ -10,7 +10,7 @@
 
 	rr:logicalTable [ rr:tableName  "\"IOUs\"" ];
 	
-    rr:subjectMap [ rr:template "{\"fname\"}_{\"lname\"}_{\"amount\"}"; rr:termType rr:BlankNode; ];
+    rr:subjectMap [ rr:template "{\"fname\"}{\"lname\"}{\"amount\"}"; rr:termType rr:BlankNode; ];
     
     rr:predicateObjectMap [
     	rr:predicate rdf:type;
@@ -41,7 +41,7 @@
 
 	rr:logicalTable [ rr:tableName  "\"Lives\"" ];
 	
-    rr:subjectMap [ rr:template "{\"fname\"}_{\"lname\"}_{\"city\"}"; rr:termType rr:BlankNode; ];
+    rr:subjectMap [ rr:template "{\"fname\"}{\"lname\"}{\"city\"}"; rr:termType rr:BlankNode; ];
     
     rr:predicateObjectMap [
     	rr:predicate rdf:type;


### PR DESCRIPTION
Test cases 0005b, 0012a, 0012e have a mismatch between mapping and expected output, making the test fail under correct operation. 

These mismatches are also present in the [R2RML and Direct Mapping Test Cases](https://www.w3.org/2001/sw/rdb2rdf/test-cases/#R2RMLTC0005b) document hosted at w3.org.

For example, in case 0005b: 

[r2rmlb.ttl](https://github.com/kg-construct/r2rml-test-cases-support/blob/main/R2RMLTC0005b/r2rmlb.ttl):
```turtle
rr:subjectMap [ rr:template "{\"fname\"}_{\"lname\"}";
                    rr:class <IOUs>;
                    rr:termType rr:BlankNode; ];
```
[mappedb.nq](https://github.com/kg-construct/r2rml-test-cases-support/blob/main/R2RMLTC0005b/mappedb.nq):

```rdf
_:BobSmith <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/base/IOUs> .
_:BobSmith <http://example.com/base/IOUs#fname> "Bob" .
_:BobSmith <http://example.com/base/IOUs#lname> "Smith" .
_:BobSmith <http://example.com/base/IOUs#amount> "3.0E1"^^<http://www.w3.org/2001/XMLSchema#double> .
```

In this pull request I propose to rectify this mismatch by fitting the mapping file to the expected output already present. 

